### PR TITLE
Add an optional CIFS security option to fill in the mount.cifs sec field

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The method below will install the sysvinit and /etc/default options that can be 
 **1. Run the plugin - can be added to systemd or run in the background**
 
 ```
-  $ sudo docker-volume-netshare cifs --username user --password pass --domain domain
+  $ sudo docker-volume-netshare cifs --username user --password pass --domain domain --security security
 ```
 
 **2. Launch a container**
@@ -115,6 +115,7 @@ See example:
        username  jeremy
        password  somepass
        domain    optional
+       security  optional
 ```
 
 **2. Run the plugin**
@@ -146,7 +147,7 @@ options and other info can be eliminated when running a container.
 This will create a new volume via the Docker daemon which will call `Create` in netshare passing in the corresponding user, pass and domain info.
 
 ```
-  $ docker volume create -d cifs --name cifshost/share --opt username=user --opt password=pass --opt domain=domain
+  $ docker volume create -d cifs --name cifshost/share --opt username=user --opt password=pass --opt domain=domain --opt security=security
 ```
 
 **3. Launch a container**
@@ -155,6 +156,10 @@ This will create a new volume via the Docker daemon which will call `Create` in 
   // cifs/share matches the volume as defined in Step #2 using docker volume create
   $ docker run -it -v cifshost/share:/mount ubuntu /bin/bash
 ```
+
+#### Security Option
+Some CIFS servers may require a specific security mode to connect. The ``security`` option defines the ``sec`` option that is passed to ``mount.cifs``. [More information about available ``sec`` options](https://www.samba.org/samba/docs/man/manpages-3/mount.cifs.8.html).
+e.g.: Apple Time Capsule's require the security mode ``ntlm``.
 
 ## License
 

--- a/netshare/drivers/cifs.go
+++ b/netshare/drivers/cifs.go
@@ -16,6 +16,7 @@ const (
 	UsernameOpt = "username"
 	PasswordOpt = "password"
 	DomainOpt   = "domain"
+	SecurityOpt = "security"
 )
 
 type cifsDriver struct {
@@ -159,6 +160,9 @@ func (s cifsDriver) mountVolume(source, dest string, creds *cifsCreds) error {
 		}
 		if v, found := mopts[DomainOpt]; found {
 			domain = v
+		}
+		if v, found := mopts[SecurityOpt]; found {
+			security = v
 		}
 	}
 

--- a/netshare/drivers/cifs.go
+++ b/netshare/drivers/cifs.go
@@ -27,15 +27,16 @@ type cifsDriver struct {
 }
 
 type cifsCreds struct {
-	user   string
-	pass   string
-	domain string
+	user     string
+	pass	 string
+	domain   string
+	security string
 }
 
-func NewCIFSDriver(root, user, pass, domain string) cifsDriver {
+func NewCIFSDriver(root, user, pass, domain, security string) cifsDriver {
 	d := cifsDriver{
 		root:   root,
-		creds:  &cifsCreds{user: user, pass: pass, domain: domain},
+		creds:  &cifsCreds{user: user, pass: pass, domain: domain, security : security},
 		netrc:  parseNetRC(),
 		mountm: NewVolumeManager(),
 		m:      &sync.Mutex{},
@@ -146,6 +147,7 @@ func (s cifsDriver) mountVolume(source, dest string, creds *cifsCreds) error {
 	var user = creds.user
 	var pass = creds.pass
 	var domain = creds.domain
+	var security = creds.security
 
 	if s.mountm.HasOptions(dest) {
 		mopts := s.mountm.GetOptions(dest)
@@ -172,6 +174,11 @@ func (s cifsDriver) mountVolume(source, dest string, creds *cifsCreds) error {
 	if domain != "" {
 		opts.WriteString(fmt.Sprintf("domain=%s,", domain))
 	}
+
+	if security != "" {
+		opts.WriteString(fmt.Sprintf("sec=%s,", security))
+	}
+
 	opts.WriteString("rw ")
 
 	opts.WriteString(fmt.Sprintf("%s %s", source, dest))
@@ -186,9 +193,10 @@ func (s cifsDriver) getCreds(host string) *cifsCreds {
 		m := s.netrc.Machine(host)
 		if m != nil {
 			return &cifsCreds{
-				user:   m.Get("username"),
-				pass:   m.Get("password"),
-				domain: m.Get("domain"),
+				user:     m.Get("username"),
+				pass:     m.Get("password"),
+				domain:   m.Get("domain"),
+				security: m.Get("security"),
 			}
 		}
 	}

--- a/netshare/netshare.go
+++ b/netshare/netshare.go
@@ -15,6 +15,7 @@ const (
 	UsernameFlag   = "username"
 	PasswordFlag   = "password"
 	DomainFlag     = "domain"
+	SecurityFlag   = "security"
 	VersionFlag    = "version"
 	BasedirFlag    = "basedir"
 	VerboseFlag    = "verbose"
@@ -26,6 +27,7 @@ const (
 	EnvSambaUser   = "NETSHARE_CIFS_USERNAME"
 	EnvSambaPass   = "NETSHARE_CIFS_PASSWORD"
 	EnvSambaWG     = "NETSHARE_CIFS_DOMAIN"
+	EnvSambaSec    = "NETSHARE_CIFS_SECURITY"
 	EnvNfsVers     = "NETSHARE_NFS_VERSION"
 	EnvTCP         = "NETSHARE_TCP_ENABLED"
 	EnvTCPAddr     = "NETSHARE_TCP_ADDR"
@@ -122,8 +124,9 @@ func execCIFS(cmd *cobra.Command, args []string) {
 	user := typeOrEnv(cmd, UsernameFlag, EnvSambaUser)
 	pass := typeOrEnv(cmd, PasswordFlag, EnvSambaPass)
 	domain := typeOrEnv(cmd, DomainFlag, EnvSambaWG)
+	security := typeOrEnv(cmd, SecurityFlag, EnvSambaSec)
 
-	d := drivers.NewCIFSDriver(rootForType(drivers.CIFS), user, pass, domain)
+	d := drivers.NewCIFSDriver(rootForType(drivers.CIFS), user, pass, domain, security)
 	start(drivers.CIFS, d)
 }
 

--- a/netshare/netshare.go
+++ b/netshare/netshare.go
@@ -83,6 +83,7 @@ func setupFlags() {
 	cifsCmd.Flags().StringP(UsernameFlag, "u", "", "Username to use for mounts.  Can also set environment NETSHARE_CIFS_USERNAME")
 	cifsCmd.Flags().StringP(PasswordFlag, "p", "", "Password to use for mounts.  Can also set environment NETSHARE_CIFS_PASSWORD")
 	cifsCmd.Flags().StringP(DomainFlag, "d", "", "Domain to use for mounts.  Can also set environment NETSHARE_CIFS_DOMAIN")
+	cifsCmd.Flags().StringP(SecurityFlag. "s", "", "Security mode to use for mounts (mount.cifs's sec option). Can also set environment NETSHARE_CIFS_SECURITY.")
 
 	nfsCmd.Flags().IntP(VersionFlag, "v", 4, "NFS Version to use [3 | 4]. Can also be set with NETSHARE_NFS_VERSION")
 

--- a/netshare/netshare.go
+++ b/netshare/netshare.go
@@ -83,7 +83,7 @@ func setupFlags() {
 	cifsCmd.Flags().StringP(UsernameFlag, "u", "", "Username to use for mounts.  Can also set environment NETSHARE_CIFS_USERNAME")
 	cifsCmd.Flags().StringP(PasswordFlag, "p", "", "Password to use for mounts.  Can also set environment NETSHARE_CIFS_PASSWORD")
 	cifsCmd.Flags().StringP(DomainFlag, "d", "", "Domain to use for mounts.  Can also set environment NETSHARE_CIFS_DOMAIN")
-	cifsCmd.Flags().StringP(SecurityFlag. "s", "", "Security mode to use for mounts (mount.cifs's sec option). Can also set environment NETSHARE_CIFS_SECURITY.")
+	cifsCmd.Flags().StringP(SecurityFlag, "s", "", "Security mode to use for mounts (mount.cifs's sec option). Can also set environment NETSHARE_CIFS_SECURITY.")
 
 	nfsCmd.Flags().IntP(VersionFlag, "v", 4, "NFS Version to use [3 | 4]. Can also be set with NETSHARE_NFS_VERSION")
 


### PR DESCRIPTION
I have an Apple Time Capsule. When you connect to these you need to define ``sec=ntlm``. Without this option I get a permission denied error.

Let me know if there is anything I need to change.

Interestingly, when I had the drive manually mounted with the sec option and setup my containers with netshare, it connects fine, making it confusing to figure out what the problem was!